### PR TITLE
Changed remaining references of toddledev to nordcraftengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ To preview the documentation locally:
 
 If you find issues or have suggestions for the documentation:
 
-1. Check existing [issues](https://github.com/toddledev/documentation/issues) to see if it's already been reported
-2. Open a [new issue](https://github.com/toddledev/documentation/issues/new) describing the problem or suggestion in detail
+1. Check existing [issues](https://github.com/nordcraftengine/documentation/issues) to see if it's already been reported
+2. Open a [new issue](https://github.com/nordcraftengine/documentation/issues/new) describing the problem or suggestion in detail
 
 ## License
 The Nordcraft documentation is licensed under [Apache License](LICENSE).

--- a/docs/18-guides/99-contribution-guide/index.md
+++ b/docs/18-guides/99-contribution-guide/index.md
@@ -11,7 +11,7 @@ The Nordcraft documentation is organized into sections and individual pages:
 - **Sections**: Main categories like "Get started," "Components," or "Styling"
 - **Pages**: Individual documents that can be either within sections or standalone (like "About" page)
 
-Each section and page corresponds to a folder in the [GitHub repository](https://github.com/toddledev/documentation):
+Each section and page corresponds to a folder in the [GitHub repository](https://github.com/nordcraftengine/documentation):
 - Sections and pages are numbered (01, 02, 03...) to determine their order in the side menu
 - The content of each page is stored in an `index.md` markdown file
 - All related images are placed in the same folder as the page's `index.md` file
@@ -186,7 +186,7 @@ Following these guidelines will help ensure that the Nordcraft documentation rem
 :::
 
 # Contributing via GitHub
-Since the Nordcraft documentation is hosted on [GitHub](https://github.com/toddledev/documentation), you will need to follow standard Git workflows to contribute:
+Since the Nordcraft documentation is hosted on [GitHub](https://github.com/nordcraftengine/documentation), you will need to follow standard Git workflows to contribute:
 1. **Fork the repository**: Create your own copy of the documentation repository
 2. **Clone locally**: Download your fork to your local machine
 3. **Create a branch**: Make a new branch for your contribution
@@ -224,7 +224,7 @@ To preview documentation pages while you're working on them:
 This preview feature allows you to see how your changes will look before they're published, making it easier to identify and fix formatting issues.
 
 # Code of conduct
-By participating in the Nordcraft documentation project, you agree to abide by the project's [Code of Conduct](https://github.com/toddledev/documentation/blob/main/CODE_OF_CONDUCT.md). This ensures a welcoming and inclusive environment for all contributors.
+By participating in the Nordcraft documentation project, you agree to abide by the project's [Code of Conduct](https://github.com/nordcraftengine/documentation/blob/main/CODE_OF_CONDUCT.md). This ensures a welcoming and inclusive environment for all contributors.
 
 # Questions and support
 If you have questions about contributing to the documentation or need assistance with your contributions:

--- a/proxy/bin/buildAssets.ts
+++ b/proxy/bin/buildAssets.ts
@@ -33,7 +33,7 @@ const menuItems = getMenuItemsFromRepoItems({
     type: 'tree',
   })),
   parentPath: 'docs',
-  owner: 'toddledev',
+  owner: 'nordcraftengine',
   repository: 'documentation',
   branch: 'main',
 })

--- a/proxy/bin/buildContributors.ts
+++ b/proxy/bin/buildContributors.ts
@@ -27,7 +27,7 @@ for (const c of chunks) {
   await Promise.all(
     c.map(async (path) => {
       const fileContributors = await fetchContributors({
-        owner: 'toddledev',
+        owner: 'nordcraftengine',
         repository: 'documentation',
         path: `docs/${path}`,
       })

--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -20,7 +20,7 @@ app.use(
   }),
 )
 
-// URLs like: http://localhost:9000/content/toddledev/documentation/main/the-editor/canvas
+// URLs like: http://localhost:9000/content/nordcraftengine/documentation/main/the-editor/canvas
 app.get('/content/:owner/:repository/:branch/:path{.*}?', async (ctx) => {
   const owner = ctx.req.param('owner')
   const repository = ctx.req.param('repository')

--- a/proxy/src/routes/fetchContent.ts
+++ b/proxy/src/routes/fetchContent.ts
@@ -11,7 +11,7 @@ import {
 import { loadJsonFile } from '../utils/jsonLoader'
 import { loadMarkdownFile } from '../utils/markdownLoader'
 
-// URLs like: http://localhost:8989/content/toddledev/documentation/main/the-editor/canvas
+// URLs like: http://localhost:8989/content/nordcraftengine/documentation/main/the-editor/canvas
 export const fetchContent = async ({
   params: { owner, repository, branch, path },
 }: FetchContent) => {


### PR DESCRIPTION
# Documentation Pull Request

## Description
In the worker and in the docs, there were still references to toddledev. Since the owner of the repository changed, this was adjusted to nordcraftengine.

## Type of change
Please check the options that are relevant:
- [x] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [x] Other (please describe): Adjusted build scripts for menu and contributors

## Checklist
Before submitting your PR, please confirm that:
- [x] My changes follow the formatting guidelines in the contribution guide
- [x] I have performed a self-review of my changes
- [x] I have tested all links to ensure they point to valid pages
- [x] I have verified that images display correctly
- [x] I have checked examples (if applicable) to ensure they work correctly
- [x] I have used consistent terminology throughout the documentation
- [x] I have placed content in the correct numbered folders to maintain proper ordering
- [x] I have checked my changes for spelling and grammatical errors