### PR TITLE
Add privacy friendly thumbnail proxy route

### DIFF
--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { secureHeaders } from 'hono/secure-headers'
 import { handleFeedback } from './clickhouse/clickhouse'
-import { fetchContent, fetchMenu, search } from './routes'
+import { fetchContent, fetchMenu, handleThumbnail, search } from './routes'
 import type { Env, MenuItem } from './types'
 import { errorResponse, getFilePathWithLocal } from './utils'
 import { loadJsonFile } from './utils/jsonLoader'
@@ -112,5 +112,7 @@ app.post('/search', async (ctx) => {
 })
 
 app.post('/feedback', handleFeedback)
+
+app.get('/video-thumbnail/:videoId', handleThumbnail)
 
 export default app

--- a/proxy/src/routes/index.ts
+++ b/proxy/src/routes/index.ts
@@ -1,3 +1,4 @@
 export * from './fetchContent'
 export * from './fetchMenu'
 export * from './search'
+export * from './thumbnail'

--- a/proxy/src/routes/thumbnail.ts
+++ b/proxy/src/routes/thumbnail.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'hono'
+
+export const handleThumbnail = async (ctx: Context) => {
+  const videoId = ctx.req.param('videoId')
+  const url = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
+  const response = await fetch(url)
+  if (!response.ok) {
+    return new Response(null, {
+      status: 404,
+      headers: {
+        'Content-Type': 'image/jpeg',
+      },
+    })
+  }
+  const contentType = response.headers.get('Content-Type')
+  const contentLength = response.headers.get('Content-Length')
+  const headers = new Headers()
+  headers.set('Content-Type', contentType ?? 'image/jpeg')
+  headers.set('Content-Length', contentLength ?? '0')
+  headers.set('Cache-Control', 'public, max-age=3600')
+  return new Response(response.body, {
+    status: response.status,
+    headers,
+  })
+}


### PR DESCRIPTION
To avoid Youtube from setting cookies when we request a thumbnail, we will proxy the thumbnail request.