### PR TITLE
Allow cors requests for thumbnails

### DIFF
--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -5,6 +5,7 @@ import { handleFeedback } from './clickhouse/clickhouse'
 import { fetchContent, fetchMenu, handleThumbnail, search } from './routes'
 import type { Env, MenuItem } from './types'
 import { errorResponse, getFilePathWithLocal } from './utils'
+import { validOriginsSuffixes } from './utils/cors'
 import { loadJsonFile } from './utils/jsonLoader'
 
 const app = new Hono<{ Bindings: Env }>()
@@ -13,11 +14,7 @@ app.use(secureHeaders())
 app.use(
   cors({
     origin: (o) =>
-      o.endsWith('localhost:9000') ||
-      o.endsWith('nordcraft_docs.toddle.site') ||
-      o.endsWith('docs.nordcraft.com')
-        ? o
-        : undefined,
+      validOriginsSuffixes.some((origin) => o.endsWith(origin)) ? o : undefined,
   }),
 )
 

--- a/proxy/src/routes/thumbnail.ts
+++ b/proxy/src/routes/thumbnail.ts
@@ -18,6 +18,12 @@ export const handleThumbnail = async (ctx: Context) => {
   headers.set('Content-Type', contentType ?? 'image/jpeg')
   headers.set('Content-Length', contentLength ?? '0')
   headers.set('Cache-Control', 'public, max-age=3600')
+  headers.set(
+    'Access-Control-Allow-Origin',
+    ctx.req.raw.headers.get('Origin') ?? '*',
+  )
+  headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  headers.set('Access-Control-Max-Age', '3600')
   return new Response(response.body, {
     status: response.status,
     headers,

--- a/proxy/src/utils/cors.ts
+++ b/proxy/src/utils/cors.ts
@@ -1,0 +1,5 @@
+export const validOriginsSuffixes = [
+  'localhost:9000',
+  'nordcraft_docs.toddle.site',
+  'docs.nordcraft.com',
+]


### PR DESCRIPTION
The cors middleware did not kick in since we were sending a manual Response. Hopefully this should allow the browser to fetch proxied thumbnails