### PR TITLE
Change H4 headings in references to bold text

### DIFF
--- a/proxy/bin/libReferences/actions/arguments.md
+++ b/proxy/bin/libReferences/actions/arguments.md
@@ -1,4 +1,4 @@
-#### Arguments
+**Arguments**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/proxy/bin/libReferences/formulas/arguments.md
+++ b/proxy/bin/libReferences/formulas/arguments.md
@@ -1,4 +1,4 @@
-#### Arguments
+**Arguments**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/proxy/bin/libReferences/formulas/outputs.md
+++ b/proxy/bin/libReferences/formulas/outputs.md
@@ -1,4 +1,4 @@
-#### Output
+**Output**
 
 | Type       | Description       |
 | ---------- | ----------------- |


### PR DESCRIPTION
This is to prevent duplicate links on each reference page to e.g. #arguments and #output.