### PR TITLE
Escape markdown characters before lib generation

### DIFF
--- a/proxy/bin/libReferences/actions/actions.ts
+++ b/proxy/bin/libReferences/actions/actions.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import * as prettier from 'prettier'
+import { escapeMarkdown } from '../formatting'
 
 interface JsonAction {
   id: string
@@ -36,16 +37,19 @@ ${content.trim()}
 ${actionsJson
   .map((action) => {
     let actionContent = actionTemplate
-      .replace('{{ name }}', action.action.name)
-      .replace('{{ description }}', action.action.description ?? '')
+      .replace('{{ name }}', escapeMarkdown(action.action.name))
+      .replace(
+        '{{ description }}',
+        escapeMarkdown(action.action.description ?? ''),
+      )
     if (action.action.arguments.length > 0) {
       actionContent += '\n' + argumentsTemplate + '\n'
       actionContent += action.action.arguments
         .map((arg) => {
           return argumentTemplate
-            .replace('{{ name }}', arg.name)
-            .replace('{{ type }}', arg.type?.type ?? '')
-            .replace('{{ description }}', arg.description ?? '')
+            .replace('{{ name }}', escapeMarkdown(arg.name))
+            .replace('{{ type }}', escapeMarkdown(arg.type?.type ?? ''))
+            .replace('{{ description }}', escapeMarkdown(arg.description ?? ''))
         })
         .join('\n')
     }

--- a/proxy/bin/libReferences/formatting.ts
+++ b/proxy/bin/libReferences/formatting.ts
@@ -1,0 +1,5 @@
+/**
+ * Escape `|` and `*` characters in a string to prevent them from being interpreted as Markdown formatting.
+ */
+export const escapeMarkdown = (text: string) =>
+  text.replaceAll('|', '\\|').replaceAll('*', '\\*')

--- a/proxy/bin/libReferences/formulas/formulas.ts
+++ b/proxy/bin/libReferences/formulas/formulas.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import * as prettier from 'prettier'
+import { escapeMarkdown } from '../formatting'
 
 interface JsonFormula {
   id: string
@@ -43,16 +44,19 @@ ${content.trim()}
 ${formulasJson
   .map((formula) => {
     let formulaContent = formulaTemplate
-      .replace('{{ name }}', formula.formula.name)
-      .replace('{{ description }}', formula.formula.description ?? '')
+      .replace('{{ name }}', escapeMarkdown(formula.formula.name))
+      .replace(
+        '{{ description }}',
+        escapeMarkdown(formula.formula.description ?? ''),
+      )
     if (formula.formula.arguments.length > 0) {
       formulaContent += '\n' + argumentsTemplate + '\n'
       formulaContent += formula.formula.arguments
         .map((arg) => {
           return argumentTemplate
-            .replace('{{ name }}', arg.name)
-            .replace('{{ type }}', arg.type?.type ?? '')
-            .replace('{{ description }}', arg.description ?? '')
+            .replace('{{ name }}', escapeMarkdown(arg.name))
+            .replace('{{ type }}', escapeMarkdown(arg.type?.type ?? ''))
+            .replace('{{ description }}', escapeMarkdown(arg.description ?? ''))
         })
         .join('\n')
     }
@@ -60,10 +64,13 @@ ${formulasJson
       formulaContent +=
         '\n' +
         outputsTemplate
-          .replace('{{ type }}', formula.formula.output.type.type ?? '')
+          .replace(
+            '{{ type }}',
+            escapeMarkdown(formula.formula.output.type.type ?? ''),
+          )
           .replace(
             '{{ description }}',
-            formula.formula.output.description ?? '',
+            escapeMarkdown(formula.formula.output.description ?? ''),
           )
     }
     return formulaContent


### PR DESCRIPTION
Union types (i.e. `string | number`) would cause issues in the generated markdown files for formula/action references. This makes sure we escape `|` and `*` characters before adding them to the lib.