### PR TITLE
Make setting params clearer

### DIFF
--- a/docs/08-pages/04-static-and-dynamic/index.md
+++ b/docs/08-pages/04-static-and-dynamic/index.md
@@ -29,7 +29,7 @@ Dynamic pages display content based on data received from APIs or URL parameters
 
 To create a dynamic page:
 
-1. Set a path as a parameter in the URL configuration, which is available in the formula editor on the page
+1. Set a path as a parameter in the URL configuration by checking the `Param` checkbox
 2. Set a test value to simulate different parameter values in the editor
 
 For example, a blog page might use `/blog/:slug` where `:slug` is a parameter that determines which article to display.

--- a/docs/08-pages/04-static-and-dynamic/index.md
+++ b/docs/08-pages/04-static-and-dynamic/index.md
@@ -29,7 +29,7 @@ Dynamic pages display content based on data received from APIs or URL parameters
 
 To create a dynamic page:
 
-1. Set a path as a parameter in the URL configuration by checking the `Param` checkbox
+1. Set a path as a parameter by checking the `Param` checkbox in the page URL configuration panel
 2. Set a test value to simulate different parameter values in the editor
 
 For example, a blog page might use `/blog/:slug` where `:slug` is a parameter that determines which article to display.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -22,7 +22,6 @@ The proxy works with the Nordcraft documentation site to provide a seamless expe
 - `search.ts`: Provides search functionality across documentation
 - `handleThumbnail.ts`: Proxies video thumbnails without setting cookies
 
-
 ### Build Scripts
 
 - `buildAssets.ts`: Generates static assets for the documentation site (e.g. copies markdown files and generates the menu structure)
@@ -63,4 +62,3 @@ In the `proxy` directory, run `bun run dev` to start the proxy service in develo
    - Builds the initial sitemap
    - Pre-fetches contributor information (if `COMMITS_KEY` is available)
 5. Content can be served directly from the local filesystem for rapid testing
-


### PR DESCRIPTION
Added the specific instructions to set a path as a parameter.

# Documentation Pull Request

## Description
This makes setting paths as parameters a little clearer, by referring to the checkbox.

## Type of change

- [x] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist

- [x] My changes follow the formatting guidelines in the contribution guide
- [x] I have performed a self-review of my changes
- [ ] I have tested all links to ensure they point to valid pages
- [ ] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [ ] I have used consistent terminology throughout the documentation
- [ ] I have placed content in the correct numbered folders to maintain proper ordering
- [x] I have checked my changes for spelling and grammatical errors