### PR TITLE
Encode description that contains a colon

### DIFF
--- a/docs/03-core-concepts/index.md
+++ b/docs/03-core-concepts/index.md
@@ -1,6 +1,6 @@
 ---
 title: Nordcraft core concepts
-description: Explore Nordcraft’s core principles: component architecture, reactive data flow, and visual development with code.
+description: 'Explore Nordcraft’s core principles: component architecture, reactive data flow, and visual development with code.'
 ---
 
 # Nordcaft core concepts


### PR DESCRIPTION
Since we use the [front-matter](https://www.npmjs.com/package/front-matter) package for parsing seo tags, we need to escape colons (see https://github.com/jxson/front-matter/issues/89).
I suggest we stop using a yml parser for our md files and come up with a more flexible solution 🤞
