### PR TITLE
Clarify grouped fields

### DIFF
--- a/docs/10-variables/02-working-with-variables/index.md
+++ b/docs/10-variables/02-working-with-variables/index.md
@@ -110,7 +110,7 @@ This is a shortcut that automatically sets up:
 - A change event handler on the `input` event that updates the variable when the user types
 
 :::tip
-**The `Bind to variable` dropdown is a shortcut for input fields that are not grouped**.
+**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields that share the same `name` attribute.**
 
 If you're using other form input types such as `radio`, `checkbox`, or `select` inputs, you will need to manually add change event handlers to set variable values instead of choosing the `Bind to variable` shortcut.
 

--- a/docs/10-variables/02-working-with-variables/index.md
+++ b/docs/10-variables/02-working-with-variables/index.md
@@ -110,7 +110,10 @@ This is a shortcut that automatically sets up:
 - A change event handler on the `input` event that updates the variable when the user types
 
 :::tip
-**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields (such as `option` inputs), or input fields that share the same `name` attribute (such as radio buttons).**
+**The `Bind to variable` dropdown is a shortcut for single input fields, not for:**
+
+- groups of input fields (such as `option` inputs)
+- input fields that share the same `name` attribute (such as radio buttons)
 
 If you're using other form input types such as `radio`, `checkbox`, or `select` inputs, you will need to manually add change event handlers to set variable values instead of choosing the `Bind to variable` shortcut.
 

--- a/docs/10-variables/02-working-with-variables/index.md
+++ b/docs/10-variables/02-working-with-variables/index.md
@@ -110,7 +110,7 @@ This is a shortcut that automatically sets up:
 - A change event handler on the `input` event that updates the variable when the user types
 
 :::tip
-**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields (such as option inputs), or input fields that share the same `name` attribute (such as radio buttons).**
+**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields (such as `option` inputs), or input fields that share the same `name` attribute (such as radio buttons).**
 
 If you're using other form input types such as `radio`, `checkbox`, or `select` inputs, you will need to manually add change event handlers to set variable values instead of choosing the `Bind to variable` shortcut.
 

--- a/docs/10-variables/02-working-with-variables/index.md
+++ b/docs/10-variables/02-working-with-variables/index.md
@@ -110,7 +110,7 @@ This is a shortcut that automatically sets up:
 - A change event handler on the `input` event that updates the variable when the user types
 
 :::tip
-**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields that share the same `name` attribute.**
+**The `Bind to variable` dropdown is a shortcut for single input fields, not for groups of input fields (such as option inputs), or input fields that share the same `name` attribute (such as radio buttons).**
 
 If you're using other form input types such as `radio`, `checkbox`, or `select` inputs, you will need to manually add change event handlers to set variable values instead of choosing the `Bind to variable` shortcut.
 


### PR DESCRIPTION
This clarifies with more examples what we mean by "grouped input fields" when discussing the bind to variable shortcut.