### PR TITLE
Serve unique contributors and handle nulll values

### DIFF
--- a/proxy/src/utils/res.ts
+++ b/proxy/src/utils/res.ts
@@ -19,7 +19,7 @@ export const errorResponse = (
     status: config?.status ?? 500,
     headers: {
       ...(config?.headers ?? {}),
-      'content-type': 'application/text',
+      'content-type': 'application/json',
     },
   })
 }


### PR DESCRIPTION
If a contributor was null/undefined, our script for fetching contributors would fail (see the `Deploy` step [here](https://github.com/nordcraftengine/documentation/actions/runs/15269929946/job/42942928054)).

- Handle/support contributors that are `null` or `undefined`
- Ignore contributors without an avatar URL
- Serve unique contributors (no duplicate usernames)
- Serve API errors as JSON rather than text
  