### PR TITLE
Linking to responsive design blog post

### DIFF
--- a/docs/07-styling/03-styles-and-layout/index.md
+++ b/docs/07-styling/03-styles-and-layout/index.md
@@ -72,3 +72,7 @@ When working with text content, Nordcraft defaults to **Text** layout:
 ::: info
 For more information about flow layout, see the [flow layout documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Flow_layout).
 :::
+
+::: tip
+If you want to know more about how to apply responsive design in Nordcraft, check out the [blog post about responsive design in Nordcraft](https://blog.nordcraft.com/how-toddle-thinks-about-responsive-design).
+:::

--- a/docs/07-styling/03-styles-and-layout/index.md
+++ b/docs/07-styling/03-styles-and-layout/index.md
@@ -74,5 +74,5 @@ For more information about flow layout, see the [flow layout documentation on MD
 :::
 
 ::: tip
-If you want to know more about how to apply responsive design in Nordcraft, check out the [blog post about responsive design in Nordcraft](https://blog.nordcraft.com/how-toddle-thinks-about-responsive-design).
+If you want to know more about how to apply responsive design in Nordcraft, check out the [blog post about responsive design in Nordcraft](https://blog.nordcraft.com/how-nordcraft-thinks-about-responsive-design).
 :::


### PR DESCRIPTION
# Documentation Pull Request

## Description
Added a Tip to check out the blog post about responsive design in the 'Styling -> Styles and layout' doc.

Fixes # (issue number, if applicable)
--> part of issue #190

## Type of change
<!-- Please check the options that are relevant by changing [ ] to [x] -->
- [X] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist
<!-- Before submitting your PR, please confirm that: -->
- [X] My changes follow the formatting guidelines in the contribution guide
- [X] I have performed a self-review of my changes
- [X] I have tested all links to ensure they point to valid pages
- [ ] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [X] I have used consistent terminology throughout the documentation
- [X] I have placed content in the correct numbered folders to maintain proper ordering
- [X] I have checked my changes for spelling and grammatical errors

## Directory structure changes (if applicable)
NA

## Screenshots or previews (if applicable)
NA

## Additional context
