### PR TITLE
Linking to web components blog post

### DIFF
--- a/docs/09-components/05-export-a-component/index.md
+++ b/docs/09-components/05-export-a-component/index.md
@@ -44,3 +44,7 @@ Components in Nordcraft follow the naming restrictions of web components:
 - If a component name has only one part (e.g. "item"), Nordcraft will automatically prefix it with `nordcraft` (resulting in `nordcraft-item`)
 - Component names cannot contain any special characters
 - Names are case-sensitive, but best practice is to use lowercase for compatibility
+
+::: tip
+Read more about web components and how they differ from iframes in this [blog post about web components](https://blog.nordcraft.com/built-in-nordcraft-exported-to-webflow).
+:::


### PR DESCRIPTION
# Documentation Pull Request

## Description
Adding a tip to docs/09-components/05-export-a-component/index.md. The tip suggests to check out a blog article about exporting web components (and how they differ from iframes).

Fixes # (issue number, if applicable)
--> part of #190

## Type of change
<!-- Please check the options that are relevant by changing [ ] to [x] -->
- [X] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist
<!-- Before submitting your PR, please confirm that: -->
- [X] My changes follow the formatting guidelines in the contribution guide
- [X] I have performed a self-review of my changes
- [X] I have tested all links to ensure they point to valid pages
- [ ] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [X] I have used consistent terminology throughout the documentation
- [ ] I have placed content in the correct numbered folders to maintain proper ordering
- [X] I have checked my changes for spelling and grammatical errors

## Directory structure changes (if applicable)
NA

## Screenshots or previews (if applicable)
NA

## Additional context
