### PR TITLE
Fetch contributors using git log

### DIFF
--- a/proxy/bin/buildContributors.ts
+++ b/proxy/bin/buildContributors.ts
@@ -2,6 +2,11 @@ import * as fs from 'fs'
 import { chunk } from 'lodash'
 import { fetchContributors } from './fetchContributors'
 
+interface CommitAuthor {
+  avatar_url?: string
+  login?: string
+}
+
 if (!fs.existsSync('./dist')) {
   fs.mkdirSync('./dist')
 }
@@ -23,13 +28,53 @@ const files = (
 const chunks = chunk(files, 10)
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const contributorMapFile = fs.readFileSync('./contributors.json', 'utf-8')
+const contributorMap = JSON.parse(contributorMapFile) as Array<{
+  email: string
+  username: string
+}>
+const getGitHubUser = async (username: string) => {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'CF',
+  }
+  if (process.env.COMMITS_KEY) {
+    headers.Authorization = `Bearer ${process.env.COMMITS_KEY}`
+  }
+  const response = await fetch(`https://api.github.com/users/${username}`, {
+    headers,
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch GitHub user: ${response.statusText}`)
+  }
+  return response.json() as Promise<CommitAuthor>
+}
+const allContributors = await Promise.all(
+  contributorMap.map(async (contributor) => {
+    try {
+      const user = await getGitHubUser(contributor.username)
+      if (user.avatar_url) {
+        return {
+          ...contributor,
+          avatar: user.avatar_url,
+        }
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Failed to fetch GitHub user for ${contributor.username}:`,
+        error,
+      )
+    }
+    return contributor
+  }),
+)
 for (const c of chunks) {
   await Promise.all(
     c.map(async (path) => {
       const fileContributors = await fetchContributors({
-        owner: 'nordcraftengine',
-        repository: 'documentation',
         path: `docs/${path}`,
+        allContributors,
       })
       if (fileContributors) {
         fs.writeFileSync(

--- a/proxy/contributors.json
+++ b/proxy/contributors.json
@@ -1,0 +1,53 @@
+[
+  { "email": "andreas@toddle.dev", "username": "cullophid" },
+  {
+    "email": "157343793+ArmandGit@users.noreply.github.com",
+    "username": "armand-lrt"
+  },
+  {
+    "email": "157343793+armand-lrt@users.noreply.github.com",
+    "username": "armand-lrt"
+  },
+  { "email": "chrislaupama@icloud.com", "username": "chrislaupama" },
+  { "email": "christian@toddle.dev", "username": "ChrEsb" },
+  {
+    "email": "daniel-philip-johnson@outlook.com",
+    "username": "danielphilipjohnson"
+  },
+  {
+    "email": "32451595+erik-beus@users.noreply.github.com",
+    "username": "erik-beus"
+  },
+  { "email": "bager.erik@gmail.com", "username": "erik-beus" },
+  {
+    "email": "67047565+BoniFederico@users.noreply.github.com",
+    "username": "BoniFederico"
+  },
+  { "email": "franz@spark-agency.io", "username": "franz-baur" },
+  { "email": "franz@zenodev.com", "username": "franz-baur" },
+  { "email": "jacob.m.kofoed@gmail.com", "username": "jacob-kofoed" },
+  {
+    "email": "114390842+kasper-svenning@users.noreply.github.com",
+    "username": "kasper-svenning"
+  },
+  {
+    "email": "114390842+kaspertoddle@users.noreply.github.com",
+    "username": "kasper-svenning"
+  },
+  {
+    "email": "118650489+kuldeeparmar@users.noreply.github.com",
+    "username": "kuldeeparmar"
+  },
+  {
+    "email": "84563442+spark-agency@users.noreply.github.com",
+    "username": "max-kayr"
+  },
+  {
+    "email": "92308896+Prankisster@users.noreply.github.com",
+    "username": "Prankisster"
+  },
+  {
+    "email": "52798353+whitep4nth3r@users.noreply.github.com",
+    "username": "whitep4nth3r"
+  }
+]


### PR DESCRIPTION
Using GitHub's commit API did not respect contributors across file renames. Instead, we now use `git log --follow` to fetch contributors for each file, which provides a more accurate history of contributions. This does mean we need to maintain a map of contributor emails to usernames, which is stored in `contributors.json`.