### PR TITLE
Adjust subdomain for feature flags link

### DIFF
--- a/docs/20-guides/03-feature-flags/index.md
+++ b/docs/20-guides/03-feature-flags/index.md
@@ -10,7 +10,7 @@ If you enjoy testing beta features in software, you may like to try out some of 
 To enable experimental features:
 
 1. Sign in to your Nordcraft account
-2. Navigate to the [feature flags](https://app.nordcraft.com/flags) page
+2. Navigate to the [feature flags](https://editor.nordcraft.com/flags) page
 3. Accept the disclaimer
 4. Toggle any features you would like to enable or disable
 5. Refresh the Nordcraft editor in your browser to apply any changes


### PR DESCRIPTION
Since we mainly use feature flags in the editor, we should link to the editor subdomain instead of the "app" subdomain that will be used for Nordcraft admin pages only going forward.