### PR TITLE
Update workflows editor links to working examples

### DIFF
--- a/docs/14-workflows/02-working-with-workflows/index.md
+++ b/docs/14-workflows/02-working-with-workflows/index.md
@@ -22,7 +22,7 @@ To create a workflow on an event:
 
 If you have logic in your component that you need multiple times or if the logic tree is complex, you can create a reusable workflow from the [data panel](/the-editor/data-panel#workflows).
 
-![Create reusable workflow|16/9](create-reusable-workflow.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-height=800&canvas-width=800&mode=design&selection=workflows.Zpfk7v&rightpanel=events0}
+![Create reusable workflow|16/9](create-reusable-workflow.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-width=800&canvas-height=800&selection=workflows.Zpfk7v&rightpanel=events}
 
 To create a reusable workflow:
 

--- a/docs/14-workflows/02-working-with-workflows/index.md
+++ b/docs/14-workflows/02-working-with-workflows/index.md
@@ -11,7 +11,7 @@ Learn how to create event-triggered and reusable workflows with parameters and s
 
 You can create a workflown on any event in Nordcraft. This can be a standard JavaScript event on an element, a custom [event on a component](/components/interface-and-lifecycle#setting-up-events) or lifecycle events like `On load` or `On attribute change`.
 
-![Create a workflow|16/9](create-workflow-on-event.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-width=800&selection=nodes.root.events.onClick&rightpanel=events&canvas-height=800}
+![Create a workflow|16/9](create-workflow-on-event.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-height=800&canvas-width=800&selection=nodes.root.events.onClick&rightpanel=events}
 
 To create a workflow on an event:
 
@@ -22,7 +22,7 @@ To create a workflow on an event:
 
 If you have logic in your component that you need multiple times or if the logic tree is complex, you can create a reusable workflow from the [data panel](/the-editor/data-panel#workflows).
 
-![Create reusable workflow|16/9](create-reusable-workflow.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-width=800&rightpanel=events&selection=workflows.g1E2BN&canvas-height=800}
+![Create reusable workflow|16/9](create-reusable-workflow.webp){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/screenshot-workflows?canvas-height=800&canvas-width=800&mode=design&selection=workflows.Zpfk7v&rightpanel=events0}
 
 To create a reusable workflow:
 


### PR DESCRIPTION
# Documentation Pull Request

## Description
Fixes https://github.com/nordcraftengine/documentation/issues/270

The screenshot-workflows and associated click events and workflows were missing from the docs_examples project. I added these in, replicating the screenshots already provided as best I could.

To test, verify that clicking on the "Live" links on this preview link https://docs.nordcraft.com/workflows/working-with-workflows?mode=preview&owner=nordcraftengine&repository=documentation&branch=update-workflows-editor-links take you directly to the editor with the correct panels visible.

Click the "Live" links for 

- Create a workflow
- Create a reusable workflow