### PR TITLE
Tell people how to access the theme editor and introduce consistency around naming panels

### DIFF
--- a/docs/08-the-editor/09-element-panel/index.md
+++ b/docs/08-the-editor/09-element-panel/index.md
@@ -11,15 +11,15 @@ The element panel appears in the right side of the editor when an element is sel
 
 When you select an element in the canvas or element tree, the element panel displays configuration options for that specific element. The panel has three tabs:
 
-1. [Styling](#style-tab): Configure visual appearance and layout for the element and its children
-2. [Attributes](#attributes-tab): Set HTML or component attributes for advanced behaviors
-3. [Events](#events-tab): Define workflows triggered by user interactions on the element
+1. [Styling](#style-panel): Configure visual appearance and layout for the element and its children
+2. [Attributes](#attributes-panel): Set HTML or component attributes for advanced behaviors
+3. [Events](#events-panel): Define workflows triggered by user interactions on the element
 
-## Style tab
+## Style panel
 
-The style tab allows you to control the visual appearance of elements and components.
+The style panel allows you to control the visual appearance of elements and components.
 
-![The Style tab is open showing a number of style properties available to configure on the selected HTML element. It is annotated relating to the list items below.|16/9](element-panel-styling.webp 'Styling'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=style&canvas-width=800&canvas-height=800}
+![The Style panel is open showing a number of style properties available to configure on the selected HTML element. It is annotated relating to the list items below.|16/9](element-panel-styling.webp 'Styling'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=style&canvas-width=800&canvas-height=800}
 
 1. Set [style variables](#style-variables)
 2. Define [style](#style) variants
@@ -41,7 +41,7 @@ The style section manages different visual variants of your element.
 
 - Every element has a `Default` style applied
 - Add variants with pseudo-classes (e.g. `:hover`, `:active`, `:focus-visible`)
-- Create variants using defined classes (set in the attributes tab)
+- Create variants using defined classes (set in the attributes panel)
 - Set up responsive styles with media queries for different screen sizes
 - Combine classes, pseudo-classes and media queries for more complex style variants
 - When styling a component instance, you can select and style a component's class from the outside (see [component style overrides](/styling/conditional-styles#component-style-overrides))
@@ -58,7 +58,7 @@ The CSS properties section provides a user-friendly interface to set styling pro
 
 ### CSS Editor
 
-![The CSS editor is open in the styling tab, showing CSS code in an editable IDE-like interface.|16/9](element-panel-css-editor.webp 'CSS editor'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card-container?rightpanel=style&canvas-width=800&selection=nodes.root&canvas-height=800}
+![The CSS editor is open in the style panel, showing CSS code in an editable IDE-like interface.|16/9](element-panel-css-editor.webp 'CSS editor'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card-container?rightpanel=style&canvas-width=800&selection=nodes.root&canvas-height=800}
 
 - The CSS editor provides a code view that replaces the CSS properties section
 - Edit styles directly using CSS syntax
@@ -67,11 +67,11 @@ The CSS properties section provides a user-friendly interface to set styling pro
 
 This view is particularly useful for developers comfortable with writing CSS directly or for making multiple property changes efficiently.
 
-## Attributes tab
+## Attributes panel
 
-The attributes tab allows you to configure the element HTML tag, attributes, classes and special behaviors like conditional display and repetition for the selected element.
+The attributes panel allows you to configure the element HTML tag, attributes, classes and special behaviors like conditional display and repetition for the selected element.
 
-![The attributes tab is visible for the selected HTML element. The HTML element tag is editable via a dropdown, one attribute is specified on the element, and there is an empty classes list and the option to create show formula for this element.|16/9](element-panel-attributes.webp 'Attributes'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=attributes&canvas-width=800&canvas-height=800}
+![The attributes panel is visible for the selected HTML element. The HTML element tag is editable via a dropdown, one attribute is specified on the element, and there is an empty classes list and the option to create show formula for this element.|16/9](element-panel-attributes.webp 'Attributes'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=attributes&canvas-width=800&canvas-height=800}
 
 ### Element tag
 
@@ -89,7 +89,7 @@ The attributes tab allows you to configure the element HTML tag, attributes, cla
 
 - Add CSS classes to elements by entering a name and pressing enter
 - Bind classes to conditions to apply them dynamically via the `fx` button
-- Classes added here can be targeted in the style tab as a style variant
+- Classes added here can be targeted in the style panel as a style variant
 - Classes cannot be added directly to components
 
 ### Special behaviors
@@ -101,11 +101,11 @@ The attributes tab allows you to configure the element HTML tag, attributes, cla
 See the [show hide formula](/formulas/show-hide-formula) page and [repeat formula](/formulas/repeat-formula) page for more details.
 :::
 
-## Events tab
+## Events panel
 
-The events tab enables you to define interactive behaviors that respond to user actions on elements.
+The events panel enables you to define interactive behaviors that respond to user actions on elements.
 
-![The events tab is visible in the right sidebar, showing a number of options to add events to HTML elements, including click events, keyboard events, form, input, touch and mouse events, and more.|16/9](element-panel-events.webp 'Events'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=events&canvas-width=800&canvas-height=800}
+![The events panel is visible in the right sidebar, showing a number of options to add events to HTML elements, including click events, keyboard events, form, input, touch and mouse events, and more.|16/9](element-panel-events.webp 'Events'){https://editor.nordcraft.com/projects/docs_examples/branches/main/components/card?selection=nodes.root&rightpanel=events&canvas-width=800&canvas-height=800}
 
 - Events are categorized into logical groups (click, keyboard, form, input, touch, etc.) for easier navigation
 - Events with assigned workflows or actions are highlighted and appear in the **Active** section at the top

--- a/docs/08-the-editor/10-shortcuts/index.md
+++ b/docs/08-the-editor/10-shortcuts/index.md
@@ -20,9 +20,9 @@ These shortcuts work anywhere in the editor:
 
 When an element or component is selected in the canvas or element tree:
 
-- [kbd]S[kbd] - Switch to the [style tab](/the-editor/element-panel#style-tab) in the element panel
-- [kbd]A[kbd] - Switch to the [attributes tab](/the-editor/element-panel#attributes-tab) in the element panel
-- [kbd]E[kbd] - Switch to the [events tab](/the-editor/element-panel#events-tab) in the element panel
+- [kbd]S[kbd] - Switch to the [style panel](/the-editor/element-panel#style-panel) in the element panel
+- [kbd]A[kbd] - Switch to the [attributes panel](/the-editor/element-panel#attributes-panel) in the element panel
+- [kbd]E[kbd] - Switch to the [events panel](/the-editor/element-panel#events-panel) in the element panel
 
 ## Element tree and canvas shortcuts
 

--- a/docs/09-building-blocks/02-elements/index.md
+++ b/docs/09-building-blocks/02-elements/index.md
@@ -40,7 +40,7 @@ HTML elements can be configured using attributes. These provide additional infor
 - Common attributes like `id` and `class` can be applied to nearly all elements
 - Element-specific attributes like `src` for media elements or `type` for input elements define their unique properties
 
-You can modify an element's attributes in the [attributes tab](/the-editor/element-panel#attributes-tab) of the [element panel](/the-editor/element-panel).
+You can modify an element's attributes in the [attributes panel](/the-editor/element-panel#attributes-panel) of the [element panel](/the-editor/element-panel).
 
 :::tip
 For HTML element attributes that traditionally don't require a value to be specified (such as `open` for `<details>` and `<dialog>`, or `readonly` for `<textarea>`, add the relevant attribute to the element and set the value to `true`.
@@ -54,7 +54,7 @@ For a complete list of HTML attributes, refer to the [HTML Attribute reference o
 
 HTML elements can respond to user interactions through events. You can listen to all standard events on any element, and the editor allows you to add non-standard events if needed.
 
-Events are configured in the [events tab](/the-editor/element-panel#events-tab) of the [element panel](/the-editor/element-panel).
+Events are configured in the [events panel](/the-editor/element-panel#events-panel) of the [element panel](/the-editor/element-panel).
 
 ::: info
 For detailed information about all available events, see the [Events reference on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event).

--- a/docs/10-styling/02-theme/index.md
+++ b/docs/10-styling/02-theme/index.md
@@ -5,7 +5,9 @@ description: Create design systems with Nordcraft's theme tools for managing col
 
 # Theme
 
-The theme system in Nordcraft provides a centralized way to manage design tokens across your entire project. By defining colors, spacing, typography and other visual elements in one place, you can ensure consistent styling throughout your application.
+The theme system in Nordcraft provides a centralized way to manage design tokens across your entire project. By defining colors, spacing, typography and other visual elements in one place, you can ensure consistent styling throughout your application. Theme variables are available to use in the [style panel](/the-editor/element-panel#style-panel).
+
+To access the theme editor, open the [project sidebar](/the-editor/project-sidebar#project-sidebar) and find the Themes section.
 
 ![The Nordcraft theme editor. On the left are the following selectable categories: colors, spacing, fonts, font sizes, font weights, z-index. On the central canvas, a color palette of neutral grey colors, blues and greens are visible, defined as names that map to hex values. A preview of each color is shown as a rounded square.|16/9](theme.webp 'Theme'){https://editor.nordcraft.com/projects/docs_examples/branches/main/themes/Default?canvas-width=800&canvas-height=800&rightpanel=style}
 
@@ -32,7 +34,7 @@ Select and manage typography for your project:
 - Choose from available Google fonts
 - Add new fonts by clicking the [kbd]Add font[kbd] button
 
-Once added, these fonts become available in the font dropdown menu in the [style panel](/the-editor/element-panel#style-tab).
+Once added, these fonts become available in the font dropdown menu in the [style panel](/the-editor/element-panel#style-panel).
 
 ### Add custom fonts
 

--- a/docs/10-styling/02-theme/index.md
+++ b/docs/10-styling/02-theme/index.md
@@ -7,7 +7,7 @@ description: Create design systems with Nordcraft's theme tools for managing col
 
 The theme system in Nordcraft provides a centralized way to manage design tokens across your entire project. By defining colors, spacing, typography and other visual elements in one place, you can ensure consistent styling throughout your application. Theme variables are available to use in the [style panel](/the-editor/element-panel#style-panel).
 
-To access the theme editor, open the [project sidebar](/the-editor/project-sidebar#project-sidebar) and find the Themes section.
+To access the theme editor, open the [project sidebar](/the-editor/project-sidebar#project-sidebar) and find the `Themes` section.
 
 ![The Nordcraft theme editor. On the left are the following selectable categories: colors, spacing, fonts, font sizes, font weights, z-index. On the central canvas, a color palette of neutral grey colors, blues and greens are visible, defined as names that map to hex values. A preview of each color is shown as a rounded square.|16/9](theme.webp 'Theme'){https://editor.nordcraft.com/projects/docs_examples/branches/main/themes/Default?canvas-width=800&canvas-height=800&rightpanel=style}
 

--- a/docs/10-styling/03-styles-and-layout/index.md
+++ b/docs/10-styling/03-styles-and-layout/index.md
@@ -27,7 +27,7 @@ The style panel provides an interface for applying styles without needing to wri
 
 If you prefer writing CSS:
 
-- Access the [CSS editor](/the-editor/element-panel#css-editor) by clicking the [kbd]{ }[kbd] button at the bottom of the [style panel](/the-editor/element-panel#style-tab)
+- Access the [CSS editor](/the-editor/element-panel#css-editor) by clicking the [kbd]{ }[kbd] button at the bottom of the [style panel](/the-editor/element-panel#style-panel)
 - Write traditional CSS syntax for complete control over styling
 - View all defined styles and their properties in one place
 - Switch seamlessly between the style panel and CSS editor view, where your CSS will be reflected in the style panel properties

--- a/docs/10-styling/04-conditional-styles/index.md
+++ b/docs/10-styling/04-conditional-styles/index.md
@@ -23,10 +23,10 @@ height: 18rem
 Hover or tap the card to see the style change. This is achieved by setting the `:hover` pseudo-class.
 @@@
 
-In the **Style** section of the style tab panel, you can create additional style variants that apply only when specific conditions are met:
+In the **Style** section of the style panel, you can create additional style variants that apply only when specific conditions are met:
 
 - Pseudo-classes (`:hover`, `:active`, `:focus`, etc.)
-- [Classes](#class-based-styles) defined in the [attributes tab](/the-editor/element-panel#attributes-tab)
+- [Classes](#class-based-styles) defined in the [attributes panel](/the-editor/element-panel#attributes-panel)
 - Media queries for different screen sizes
 - [Starting style](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style)
 - Pseudo-elements (`::before`, `::after`, etc.)
@@ -53,7 +53,7 @@ For more information on pseudo-elements, see the [MDN documentation on pseudo-el
 
 ## Class-based styles
 
-You can add classes to elements using the attributes tab, and then create conditional styles for those classes.
+You can add classes to elements using the attributes panel, and then create conditional styles for those classes.
 
 @@@ example
 componentUrl: https://docs_examples.toddle.site/.toddle/custom-element/example-class-based-style.js
@@ -63,8 +63,8 @@ height: 18rem
 Click to select and unselect the card.
 @@@
 
-1. Add a class name in the **Classes** section of the [attributes tab](/the-editor/element-panel#attributes-tab)
-2. Create a new style variant in the [style tab](/the-editor/element-panel#style-tab) by selecting that class name
+1. Add a class name in the **Classes** section of the [attributes panel](/the-editor/element-panel#attributes-panel)
+2. Create a new style variant in the [style panel](/the-editor/element-panel#style-panel) by selecting that class name
 3. Define the styles that should apply when the class is applied
 
 Classes can be conditionally applied using formulas, variables, or attributes. If the condition evaluates to a truthy value, the class and its associated styles will be applied.
@@ -95,7 +95,7 @@ Style variables create dynamic styles based on state. Click the card to toggle i
 
 Create style variables with dynamic values by binding them to formulas, attributes, or variables:
 
-1. Define a style variable in the [Style variables](/the-editor/element-panel#style-tab) section
+1. Define a style variable in the [Style variables](/the-editor/element-panel#style-panel) section
 2. Use the [formula editor](/formulas/overview#the-formula-editor) to create conditional logic
 3. Reference the variable in your CSS properties
 
@@ -162,7 +162,7 @@ This approach allows you to customize individual component instances when needed
 To apply conditional styling to a component instance:
 
 1. Select the component in the canvas or element tree
-2. Add a style in the [style tab](/the-editor/element-panel#style-tab)
+2. Add a style in the [style panel](/the-editor/element-panel#style-panel)
 3. Choose from available pseudo-classes, media queries and pseudo-elements
 4. If the component has classes on its root element, these will appear in the **Class** selection dropdown
 
@@ -172,7 +172,7 @@ For consistent styling across multiple components, consider adding toggleable cl
 
 When styling component instances, there are some limitations:
 
-- You cannot add classes directly to components in the attributes tab
+- You cannot add classes directly to components in the attributes panel
 - Only classes that exist on the root element of the component can be styled from outside
 - Style variables cannot be added to components
 - You cannot style elements deeper in the component tree hierarchy

--- a/docs/12-components/03-interface-and-lifecycle/index.md
+++ b/docs/12-components/03-interface-and-lifecycle/index.md
@@ -80,7 +80,7 @@ Unlike HTML element events that trigger automatically on user interactions, comp
 
 ### Initial steps
 
-- **From an element event**: Select the triggering element (e.g. a button), go to the [events tab](/the-editor/element-panel#events-tab) and find the appropriate HTML event (e.g. `click`)
+- **From an element event**: Select the triggering element (e.g. a button), go to the [events panel](/the-editor/element-panel#events-panel) and find the appropriate HTML event (e.g. `click`)
 - **From a workflow**: Create or edit a workflow
 
 ### Common steps

--- a/docs/12-components/04-compositions/index.md
+++ b/docs/12-components/04-compositions/index.md
@@ -99,7 +99,7 @@ Slots in Nordcraft work with a naming system:
 When adding content to a component with slots:
 
 1. Select the element you want to place in a slot
-2. In the [attributes tab](/the-editor/element-panel#attributes-tab), find the **Slot** section and select which slot should contain this element.
+2. In the [attributes panel](/the-editor/element-panel#attributes-panel), find the **Slot** section and select which slot should contain this element.
 
 Elements without a specified slot are placed in the `default` slot
 

--- a/docs/14-variables/02-working-with-variables/index.md
+++ b/docs/14-variables/02-working-with-variables/index.md
@@ -101,7 +101,7 @@ You can bind variables to various aspects of elements:
 For `input` elements, Nordcraft provides a convenient shortcut to create two-way binding with variables:
 
 1. Select an input element in the element tree
-2. In the Attributes tab, find the `Bind to variable` dropdown
+2. In the attributes panel, find the `Bind to variable` dropdown
 3. Choose an existing variable or create a new one
 
 This is a shortcut that automatically sets up:
@@ -117,7 +117,7 @@ This is a shortcut that automatically sets up:
 
 If you're using other form input types such as `radio`, `checkbox`, or `select` inputs, you will need to manually add change event handlers to set variable values instead of choosing the `Bind to variable` shortcut.
 
-Additionally, in the Attributes tab you can configure `checked` or `selected` attributes for those input field types using the Formula editor.
+Additionally, in the attributes panel you can configure `checked` or `selected` attributes for those input field types using the Formula editor.
 :::
 
 @@@ example

--- a/docs/15-formulas/01-overview/index.md
+++ b/docs/15-formulas/01-overview/index.md
@@ -30,7 +30,7 @@ A pure function always returns the same result for the same input values and doe
 
 The formula editor appears when editing formulas and wherever you see an [kbd]fx[kbd] button in the Nordcraft interface:
 
-- In the [attributes panel](/the-editor/element-panel#attributes-tab) when binding values
+- In the [attributes panel](/the-editor/element-panel#attributes-panel) when binding values
 - In the [Show](/formulas/show-hide-formula) and [Repeat](/formulas/repeat-formula) sections
 - In the [style variables](/styling/conditional-styles#style-variables) panel
 - In the [data panel](/the-editor/data-panel) when defining formulas

--- a/docs/15-formulas/03-show-hide-formula/index.md
+++ b/docs/15-formulas/03-show-hide-formula/index.md
@@ -37,7 +37,7 @@ The truthy concept in Nordcraft is similar to JavaScript but follows a more stre
 To conditionally show or hide an element:
 
 1. Select the element you want to show and hide based on conditions
-2. In the [attributes tab](/the-editor/element-panel#attributes-tab), click the [kbd]fx[kbd] button next to **Show**
+2. In the [attributes panel](/the-editor/element-panel#attributes-panel), click the [kbd]fx[kbd] button next to **Show**
 3. Enter a formula that evaluates to a `Boolean` value; the element will only be visible when the formula evaluates to `true`
 
 ## How show/hide differs from CSS display

--- a/docs/15-formulas/04-repeat-formula/index.md
+++ b/docs/15-formulas/04-repeat-formula/index.md
@@ -29,7 +29,7 @@ The repeat formula:
 To create dynamic content with the repeat formula:
 
 1. Select the element you want to repeat
-2. In the [attributes tab](/the-editor/element-panel#attributes-tab), click the [kbd]fx[kbd] button next to **Repeat**
+2. In the [attributes panel](/the-editor/element-panel#attributes-panel), click the [kbd]fx[kbd] button next to **Repeat**
 3. Enter a formula that returns an `Array`; the element will be repeated for each item in the array
 4. Set a [Repeat key](#optimizing-performance-with-the-repeat-key)
 


### PR DESCRIPTION
# Documentation Pull Request

## Description
People needed to know how to access the theme editor.

Additionally, there is now consistency with how we talk about the style/attributes/events panel, which is how we refer to those areas in videos and in the Discord.

## Type of change

- [x] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist

- [x] My changes follow the formatting guidelines in the contribution guide
- [x] I have performed a self-review of my changes
- [x] I have tested all links to ensure they point to valid pages
- [ ] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [x] I have used consistent terminology throughout the documentation
- [ ] I have placed content in the correct numbered folders to maintain proper ordering
- [x] I have checked my changes for spelling and grammatical errors