### PR TITLE
Prefer dash over space in search index paths

### DIFF
--- a/proxy/bin/createSearchIndex.ts
+++ b/proxy/bin/createSearchIndex.ts
@@ -56,7 +56,7 @@ const createSearchIndex = async () => {
           [],
         )
 
-        const path = breadcrumbs.join('/')
+        const path = breadcrumbs.join('/').replaceAll(' ', '-')
 
         const title = breadcrumbs[breadcrumbs.length - 1]
 


### PR DESCRIPTION
This fixes an issue where search results would point to pages that didn't exist because the actual paths for pages don't include spaces in their urls.