### PR TITLE
Add strikethrough to deprecated action titles to style on FE

### DIFF
--- a/proxy/bin/libReferences/actions/actions.ts
+++ b/proxy/bin/libReferences/actions/actions.ts
@@ -43,7 +43,7 @@ ${actionsJson
     }
     description += action.action.description ?? ''
     let actionContent = actionTemplate
-      .replace('{{ name }}', action.action.name)
+      .replace('{{ name }}', `~~${action.action.name}~~`)
       .replace('{{ description }}', description.trim())
     if (action.action.arguments.length > 0) {
       actionContent += '\n' + argumentsTemplate + '\n'

--- a/proxy/bin/libReferences/actions/actions.ts
+++ b/proxy/bin/libReferences/actions/actions.ts
@@ -42,8 +42,12 @@ ${actionsJson
       description += `Use [${action.action.supercededBy}](/references/actions#${encodeURIComponent(action.action.supercededBy)}) instead. `
     }
     description += action.action.description ?? ''
+    const deprecation = action.action.deprecated ? '~~' : ''
     let actionContent = actionTemplate
-      .replace('{{ name }}', `~~${action.action.name}~~`)
+      .replace(
+        '{{ name }}',
+        `${deprecation}${action.action.name}${deprecation}`,
+      )
       .replace('{{ description }}', description.trim())
     if (action.action.arguments.length > 0) {
       actionContent += '\n' + argumentsTemplate + '\n'

--- a/proxy/bin/libReferences/actions/actions.ts
+++ b/proxy/bin/libReferences/actions/actions.ts
@@ -37,7 +37,7 @@ ${content.trim()}
 
 ${actionsJson
   .map((action) => {
-    let description = action.action.deprecated ? '**Deprecated** ' : ''
+    let description = action.action.deprecated ? '**Deprecated**: ' : ''
     if (action.action.supercededBy) {
       description += `Use [${action.action.supercededBy}](/references/actions#${encodeURIComponent(action.action.supercededBy)}) instead. `
     }


### PR DESCRIPTION
This is my suggestion for the deprecated action titles, and we can detect the tildas and show a strikethrough.

<img width="835" height="428" alt="image" src="https://github.com/user-attachments/assets/699c15cf-8f29-4ae5-a041-c5869da48ca6" />
