### PR TITLE
Include more content in search index

### DIFF
--- a/proxy/bin/createSearchIndex.ts
+++ b/proxy/bin/createSearchIndex.ts
@@ -124,18 +124,20 @@ const createSearchIndex = async () => {
   }
 }
 
-const firstTextToken: (data: { tokens: any[] }) => string = ({ tokens }) =>
-  tokens.reduce((acc, token) => {
-    if (typeof acc === 'string') {
-      return acc
-    } else if (token.type === 'text') {
-      return token.text
-    } else if (token.tokens) {
-      return firstTextToken({ tokens: token.tokens })
-    } else {
-      return acc
-    }
-  }, undefined)
+const firstTextToken: (data: { tokens?: any[] }) => string = (data) =>
+  data?.tokens
+    ? data.tokens.reduce((acc, token) => {
+        if (typeof acc === 'string') {
+          return acc
+        } else if (token.type === 'text') {
+          return token.text
+        } else if (token.tokens) {
+          return firstTextToken({ tokens: token.tokens })
+        } else {
+          return acc
+        }
+      }, undefined)
+    : undefined
 
 const getSearchItemsFromPages = (pages: ProcessedPage[]) => {
   const items: SearchItem[] = []
@@ -160,7 +162,7 @@ const getSearchItemsFromPages = (pages: ProcessedPage[]) => {
           breadcrumbs,
           path: path + '#' + id,
           priority: 1,
-          content: getContentFromTokens(tokens),
+          content,
         })
       }
     })
@@ -194,7 +196,10 @@ const getContentFromTokens = (tokens?: MdToken[]) => {
   ]
 
   ;(tokens ?? []).forEach((token) => {
-    if (token.type === 'text' && (token.tokens ?? []).length === 0) {
+    if (
+      token.type === 'text' ||
+      (typeof token.text === 'string' && (token.tokens ?? []).length === 0)
+    ) {
       content += token.text
     } else if (allowedTokens.includes(token.type)) {
       if (token.type === 'link') {

--- a/proxy/src/utils/frontMatter.test.ts
+++ b/proxy/src/utils/frontMatter.test.ts
@@ -1,36 +1,38 @@
-import { expect, it, test } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { getFrontMatter } from './frontMatter'
 
-test('getFrontMatter', () => {
-  it('should extract front matter and body from text', () => {
-    const { attributes, body } = getFrontMatter(`
-  ---
-  title: Test title
-  description: Test: description
-  ---
+describe('getFrontMatter', () => {
+  test('getFrontMatter', () => {
+    it('should extract front matter and body from text', () => {
+      const { attributes, body } = getFrontMatter(`
+    ---
+    title: Test title
+    description: Test: description
+    ---
 
-  # The body
+    # The body
 
-  The body
-      `)
-    expect(attributes).toEqual({
-      title: 'Test title',
-      description: 'Test: description',
+    The body
+        `)
+      expect(attributes).toEqual({
+        title: 'Test title',
+        description: 'Test: description',
+      })
+      expect(body).toBe('# The body\n\nThe body')
     })
-    expect(body).toBe('# The body\n\nThe body')
-  })
-  it('should support no front matter', () => {
-    const { attributes, body } = getFrontMatter(`
-  # The body
+    it('should support no front matter', () => {
+      const { attributes, body } = getFrontMatter(`
+    # The body
 
-  The body
-      `)
-    expect(attributes).toEqual({})
-    expect(body).toBe('# The body\n\nThe body')
-  })
-  it('should support an empty string', () => {
-    const { attributes, body } = getFrontMatter(``)
-    expect(attributes).toEqual({})
-    expect(body).toBe('')
+    The body
+        `)
+      expect(attributes).toEqual({})
+      expect(body).toBe('# The body\n\nThe body')
+    })
+    it('should support an empty string', () => {
+      const { attributes, body } = getFrontMatter(``)
+      expect(attributes).toEqual({})
+      expect(body).toBe('')
+    })
   })
 })

--- a/proxy/src/utils/helpers.test.ts
+++ b/proxy/src/utils/helpers.test.ts
@@ -1,22 +1,26 @@
-import { expect, it, test } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import { chunk, kebabCase } from './helpers'
 
-test('kebabCase', () => {
-  it('should convert a string to kebab case', () => {
-    expect(kebabCase('Hello World')).toBe('hello-world')
-    expect(kebabCase('foo_bar')).toBe('foo-bar')
-    expect(kebabCase('')).toBe('')
-    expect(kebabCase('base64')).toBe('base64')
-    expect(kebabCase('hello world _/# with special:chars')).toBe(
-      'hello-world-with-special-chars',
-    )
+describe('kebabCase', () => {
+  test('kebabCase', () => {
+    it('should convert a string to kebab case', () => {
+      expect(kebabCase('Hello World')).toBe('hello-world')
+      expect(kebabCase('foo_bar')).toBe('foo-bar')
+      expect(kebabCase('')).toBe('')
+      expect(kebabCase('base64')).toBe('base64')
+      expect(kebabCase('hello world _/# with special:chars')).toBe(
+        'hello-world-with-special-chars',
+      )
+    })
   })
 })
 
-test('chunk', () => {
-  it('should chunk an array into smaller arrays of a specified size', () => {
-    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
-    expect(chunk([1, 2, 3], 1)).toEqual([[1], [2], [3]])
-    expect(chunk([], 2)).toEqual([])
+describe('chunk', () => {
+  test('chunk', () => {
+    it('should chunk an array into smaller arrays of a specified size', () => {
+      expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+      expect(chunk([1, 2, 3], 1)).toEqual([[1], [2], [3]])
+      expect(chunk([], 2)).toEqual([])
+    })
   })
 })


### PR DESCRIPTION

`codespan` content would not be included in the search index as it did not have any tokens. Now, when a token doesn't have any tokens, we add its `text` property to the search index. After adjusting how we extract text from tokens, I had to adjust how we get the `firstTextToken` as it would break if the token was `null` I also fixed 2 tests
