### PR TITLE
Make header of app examples a h1

### DIFF
--- a/docs/app-examples/index.md
+++ b/docs/app-examples/index.md
@@ -3,7 +3,7 @@ title: App examples
 description: Explore a variety of projects built in Nordcraft, including a drum machine, a CSS only clock, and the Nordcraft editor itself.
 ---
 
-## App examples
+# App examples
 
 Explore a variety of projects built in Nordcraft, from small toy projects to full platforms in production.
 


### PR DESCRIPTION
# Documentation Pull Request

## Description

This PR changes the main header of the "App Examples" page from an h2 to an h1

## Type of change

- [x] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist

- [x] My changes follow the formatting guidelines in the contribution guide
- [x] I have performed a self-review of my changes
- [ ] I have tested all links to ensure they point to valid pages
- [ ] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [ ] I have used consistent terminology throughout the documentation
- [ ] I have placed content in the correct numbered folders to maintain proper ordering
- [ ] I have checked my changes for spelling and grammatical errors
