### PR TITLE
Add "issue rules" to references section

### DIFF
--- a/docs/index.json
+++ b/docs/index.json
@@ -368,6 +368,10 @@
       {
         "label": "Actions",
         "path": "actions"
+      },
+      {
+        "label": "Issue rules",
+        "path": "issue-rules"
       }
     ]
   }

--- a/docs/references/index.json
+++ b/docs/references/index.json
@@ -1,6 +1,0 @@
-{
-  "sections": [
-    { "path": "formulas", "label": "Formula" },
-    { "path": "actions", "label": "Actions" }
-  ]
-}

--- a/docs/references/issue-rules/index.md
+++ b/docs/references/issue-rules/index.md
@@ -1,0 +1,50 @@
+---
+title: Issue rules
+description: Improve the quality of your projects by detecting and fixing potential problems early with Nordcraft's issue rules.
+---
+
+# Issue rules
+
+Nordcraft's issue rules help you maintain high-quality standards in your projects by highlighting common problems.
+
+::: tip
+To learn more about where issue rules are shown in the editor, check out the [issues panel](/the-editor/issues-panel).
+:::
+
+::: tip
+To see how issue rules are implemented, visit the [Nordcraft GitHub repository](https://github.com/nordcraftengine/nordcraft/tree/main/packages/search/src/rules).
+:::
+
+## Actions
+
+### Project actions with no references
+
+Supports auto-fixing: Yes
+
+Project actions that are not referenced anywhere in your project can lead to confusion and bloated projects. Nordcraft flags these unused actions to help you keep your project clean and efficient.
+
+### Unknown project action references
+
+Supports auto-fixing: No
+
+Finds references to project actions that do not exist. This helps you identify and correct broken references in your project.
+
+### No console
+
+Supports auto-fixing: No
+
+Detects usage of the [Log to console](references/actions##log-to-console) action in workflows. While useful for debugging, leaving console logs in production code can lead to performance issues and cluttered output.
+
+## Formulas
+
+### Project formulas with no references
+
+Supports auto-fixing: Yes
+
+Project formulas that are not referenced anywhere in your project can lead to confusion and bloated projects. Nordcraft flags these unused formulas to help you keep your project clean and efficient.
+
+### Unknown project formula references
+
+Supports auto-fixing: No
+
+Finds references to project formulas that do not exist. This helps you identify and correct broken references in your project.


### PR DESCRIPTION
We've been discussing how to add our "issue rules" to the documentation. We talked about adding them through a `name`/`description` field on the actual rules. But that's not very flexible and could potentially bloat the problems (rules) worker output.

Instead, I suggest we add them manually here. Once we have a custom markdown parser for a GitHub link, we can also easily add links directly to the rules in the GitHub repo.